### PR TITLE
add missing close paren when handling %TimeStamp

### DIFF
--- a/AnalyzeThis/Generator.cls
+++ b/AnalyzeThis/Generator.cls
@@ -169,7 +169,7 @@ ClassMethod JSONToClass(propertiesJSON As %String, pClassName As %String) As %St
 				} Else {
 					// This is a %TimeStamp type, convert to %Date since %DeepSee.WizardUtils does not handle %TimeStamp
 					Set prop.Type="%Date"
-					Do method.Implementation.WriteLine(" Try { Set pVal=+$zdth(pVal,"_tempFormat_",,5,""99"" }")
+					Do method.Implementation.WriteLine(" Try { Set pVal=+$zdth(pVal,"_tempFormat_",,5,""99"") }")
 				}
 				Do method.Implementation.WriteLine(" Catch ex {  }")
 				Do method.Implementation.WriteLine(" Set i%"_prop.Name_"=pVal")


### PR DESCRIPTION
This change is meant to fix the error in #56.